### PR TITLE
Adjust sell ui witdh and zhTW locale update.

### DIFF
--- a/locale/zhTW.lua
+++ b/locale/zhTW.lua
@@ -153,7 +153,7 @@ L['Please refresh auctions first'] = '請先按更新，重整拍賣'
 L['Yes'] = '是'
 L['No'] = '否'
 L['Incomplete sell'] = '散裝零售'
-L['You still have %d of %s Do you wish to sell rest?'] = '你還有%d組%s，要把剩下的也賣掉嗎？'
+L['You still have %d of %s Do you wish to sell rest?'] = '你還有%d個%s，要把剩下的也賣掉嗎？'
 
 -- sell info pane
 L['Auction Info'] = '拍賣資訊'

--- a/tabs/sell/ui.lua
+++ b/tabs/sell/ui.lua
@@ -373,7 +373,7 @@ function Sell:DrawRightPaneCurrentAuctionsTable(leftMargin)
 	local cols = {
 		{
 			name         = L['Seller'],
-			width        = 120,
+			width        = 116,
 			align        = 'LEFT',
 			index        = 'owner',
 			format       = 'string',
@@ -400,14 +400,14 @@ function Sell:DrawRightPaneCurrentAuctionsTable(leftMargin)
 		},
 		{
 			name         = L['Qty'],
-			width        = 35,
+			width        = 38,
 			align        = 'LEFT',
 			index        = 'count',
 			format       = 'number',
 		},
 		{
 			name         = L['Lvl'],
-			width        = 35,
+			width        = 38,
 			align        = 'LEFT',
 			index        = 'level',
 			format       = 'number',


### PR DESCRIPTION
Fix a zhTW translate and show Qty and lvl(#68). 

But it just a minimum requirements width, will invisible again if someone use outline on font style.

feel i make commits messy O.o if the ui adjust improper, just take translate and close merge, ty