### PR TITLE
Provide item stack count to other addons

### DIFF
--- a/tabs/buy/ui.lua
+++ b/tabs/buy/ui.lua
@@ -265,6 +265,7 @@ function Buy:DrawSearchResultsTable()
 			events		 = {
 				OnEnter = function(table, cellFrame, rowFrame, rowData, columnData, rowIndex)
 					if AuctionFaster.db.buy.tooltips.enabled then
+						AuctionFaster.hoverRowData = rowData
 						AuctionFaster:ShowTooltip(
 							cellFrame,
 							rowData.itemLink,
@@ -277,6 +278,7 @@ function Buy:DrawSearchResultsTable()
 				end,
 				OnLeave = function(table, cellFrame)
 					if AuctionFaster.db.buy.tooltips.enabled then
+						AuctionFaster.hoverRowData = nil
 						AuctionFaster:ShowTooltip(cellFrame, nil, false);
 					end
 					return false;


### PR DESCRIPTION
I want to get the item stack's count but it's quite difficult to do that so this would be nice if you could put that information somewhere
https://github.com/ketho-wow/VendorPrice/commit/3c8aeae59efe55eafd6c4343cf6fb71c2202d07e

![image](https://user-images.githubusercontent.com/1073877/64576694-05e6e680-d37a-11e9-844d-2e90f0c766a5.png)
